### PR TITLE
ci; adjust cleanup workflow retention settings

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          retain_days: 7
-          keep_minimum_runs: 10
+          retain_days: 3
+          keep_minimum_runs: 5


### PR DESCRIPTION
- Reduced the `retain_days` from 7 to 3 and the `keep_minimum_runs` from 10 to 5 in the `.github/workflows/cleanup.yml` workflow configuration.