### PR TITLE
fix: add Docker metadata annotations to workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index        
         with:
           images: |
             ghcr.io/vladdoster/dotfiles
@@ -54,7 +56,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -63,6 +65,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       # - name: Build and push
       #   id: build-and-push


### PR DESCRIPTION
* Added the `DOCKER_METADATA_ANNOTATIONS_LEVELS` environment variable to the `Docker meta` step to enable annotation generation for Docker manifests and indexes.
* Updated the Docker build and push step to include annotations from the metadata action in the image publishing process.